### PR TITLE
Use multi-stage Docker build to decrease image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,14 @@
-FROM golang:onbuild
+FROM golang:1.8 AS build-env
+
 MAINTAINER Mei Akizuru
+
+RUN mkdir -p /go/src/app
+COPY . /go/src/app
+
+# download the dependencies and build the application
+RUN go-wrapper download
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go-wrapper install
+
+FROM alpine:3.5 AS runtime-env
+
+COPY --from=build-env /go/bin/app /usr/local/bin/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Mei Akizuru
 RUN mkdir -p /go/src/app
 COPY . /go/src/app
 
+WORKDIR /go/src/app
+
 # download the dependencies and build the application
 RUN go-wrapper download
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go-wrapper install


### PR DESCRIPTION
Using new multi-stage feature from Docker (available for Docker Hub for auto-build), it was possible to decrease the size of image from 721MB to ~10MB.