### PR TITLE
logrus import typo

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Server represents a simple-upload server.


### PR DESCRIPTION
```
GO111MODULE=on go get github.com/mayth/go-simple-upload-server
...
go: github.com/mayth/go-simple-upload-server imports
	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.4.2: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus
```