### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,5 @@ If you enable CORS support using `-cors` option, the server append `Access-Contr
 # Docker
 
 ```
-$ docker run -p 25478:25478 -v $HOME/tmp:/var/root mayth/simple-upload-server app -token f9403fc5f537b4ab332d /var/root
+$ docker run -p 25478:25478 -v $HOME/tmp:/var/root mayth/simple-upload-server -token f9403fc5f537b4ab332d /var/root
 ```


### PR DESCRIPTION
as the Dockfile now contains this line
```
ENTRYPOINT ["/usr/local/bin/app"] 
```
the 'app' should be removed in the docker run command, otherwise docker will treat the whole command as the 'root' argument.

example error output:
```
➜  simple-upload-server docker run -p 25478:25478 mayth/simple-upload-server app -token 123 /var/root
time="2020-04-14T07:48:07Z" level=info msg="starting up simple-upload-server"
time="2020-04-14T07:48:07Z" level=warning msg="token generated" token=17595e0cadc05dad7b7c
time="2020-04-14T07:48:07Z" level=info msg="start listening" cors=false ip=0.0.0.0 port=25478 root=app token=17595e0cadc05dad7b7c upload_limit=5242880
```