### PR TITLE
timeouts are configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Simple HTTP server to save artifacts
 - [Usage](#usage)
 - [Authentication](#authentication)
 - [TLS](#tls)
+- [Timeouts](#timeouts)
 - [Testing](#testing)
 - [API](#api)
   - [`POST /upload`](#post-upload)
@@ -20,25 +21,29 @@ Simple HTTP server to save artifacts
 
 ```
   -addr string
-        address to listen (default "127.0.0.1:8080")
+        address to listen
   -config string
         path to config file
   -document_root string
-        path to document root directory (default ".")
+        path to document root directory
   -enable_auth
         enable authentication
   -enable_cors
-        enable CORS header (default true)
+        enable CORS header
   -file_naming_strategy string
-        File naming strategy (default "uuid")
+        File naming strategy
   -max_upload_size int
-        max upload size in bytes (default 1048576)
+        max upload size in bytes
   -read_only_tokens value
         comma separated list of read only tokens
+  -read_timeout duration
+        read timeout. zero or negative value means no timeout. can be suffixed by the time units 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (e.g. '1s', '500ms'). If no suffix is provided, it is interpreted as seconds.
   -read_write_tokens value
         comma separated list of read write tokens
   -shutdown_timeout int
-        graceful shutdown timeout in milliseconds (default 15000)
+        graceful shutdown timeout in milliseconds
+  -write_timeout duration
+        write timeout. zero or negative value means no timeout. same format as read_timeout.
 ```
 
 Configurations via the arguments take precedence over those came from the config file.
@@ -78,6 +83,28 @@ As a result, the server operates like read-only mode.
 v1 has TLS support but I decided to omit it from v2.
 
 Please consider using a reverse proxy like nginx.
+
+## Timeouts
+
+(Since v2.1.0)
+
+There are 2 timeout configurations: read and write.
+The terms "read" and "write" are from the server's perspective. From clients, they are "upload" (`POST`/`PUT`) and "download" (`GET`) respectively.
+
+Read timeout (`-read_timeout`) is the maximum duration for the server reading the request.
+Clients should finish sending request headers and the entire content within this timeout.
+This is set to 15 seconds by default.
+
+Write timeout (`-write_timeout`) is the maximum duration for the server writing the response.
+Clients should finish downloading the content within this timeout.
+This timeout is not set by default. Before v2.1.0, this is set to 15 seconds.
+
+Please consider changing these timeout if:
+
+* the server or the clients are in a low-bandwidth network.
+* you are working with large files.
+
+Note that a longer timeout will result in more connections being maintained.
 
 ## Testing
 

--- a/app_test.go
+++ b/app_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	simpleuploadserver "github.com/mayth/go-simple-upload-server/v2/pkg"
 )
@@ -25,7 +26,9 @@ func Test_parseConfig(t *testing.T) {
 			"shutdown_timeout": 15000,
 			"enable_auth": true,
 			"read_only_tokens": ["foo", "bar"],
-			"read_write_tokens": ["baz", "qux"]
+			"read_write_tokens": ["baz", "qux"],
+			"read_timeout": "5s",
+			"write_timeout": "10s"
 		}`); err != nil {
 			t.Fatalf("failed to write to temp file: %v", err)
 		}
@@ -52,6 +55,8 @@ func Test_parseConfig(t *testing.T) {
 			EnableAuth:         true,
 			ReadOnlyTokens:     []string{"foo", "bar"},
 			ReadWriteTokens:    []string{"baz", "qux"},
+			ReadTimeout:        5 * time.Second,
+			WriteTimeout:       10 * time.Second,
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("parseConfig() = %v, want %v", got, want)
@@ -70,6 +75,8 @@ func Test_parseConfig(t *testing.T) {
 			"-enable_auth=true",
 			"-read_only_tokens", "foo,bar",
 			"-read_write_tokens", "baz,qux",
+			"-read_timeout", "7s",
+			"-write_timeout", "12s",
 		}
 		got, err := app.ParseConfig(args)
 		if err != nil {
@@ -86,6 +93,8 @@ func Test_parseConfig(t *testing.T) {
 			EnableAuth:         true,
 			ReadOnlyTokens:     []string{"foo", "bar"},
 			ReadWriteTokens:    []string{"baz", "qux"},
+			ReadTimeout:        7 * time.Second,
+			WriteTimeout:       12 * time.Second,
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("parseConfig() = %v, want %v", got, want)
@@ -101,6 +110,7 @@ func Test_parseConfig(t *testing.T) {
 			"-max_upload_size", "987654",
 			"-file_naming_strategy", "uuid",
 			"-shutdown_timeout", "30000",
+			"-read_timeout", "16s",
 		}
 
 		f, err := os.CreateTemp("", "simple-upload-server-config.*.json")
@@ -118,7 +128,9 @@ func Test_parseConfig(t *testing.T) {
 			"shutdown_timeout": 15000,
 			"enable_auth": true,
 			"read_only_tokens": ["alice", "bob"],
-			"read_write_tokens": ["charlie", "dave"]
+			"read_write_tokens": ["charlie", "dave"],
+			"read_timeout": "32s",
+			"write_timeout": "64s"
 		}`); err != nil {
 			t.Fatalf("failed to write to temp file: %v", err)
 		}
@@ -145,6 +157,8 @@ func Test_parseConfig(t *testing.T) {
 			EnableAuth:         true,
 			ReadOnlyTokens:     []string{"alice", "bob"},
 			ReadWriteTokens:    []string{"charlie", "dave"},
+			ReadTimeout:        16 * time.Second,
+			WriteTimeout:       64 * time.Second,
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("parseConfig() = %v, want %v", got, want)

--- a/config.json
+++ b/config.json
@@ -7,5 +7,7 @@
     "shutdown_timeout": 15000,
     "enable_auth": true,
     "read_only_tokens": [],
-    "read_write_tokens": []
+    "read_write_tokens": [],
+    "read_timeout": "30s",
+    "write_timeout": 30
 }

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -59,6 +59,10 @@ type ServerConfig struct {
 	ReadOnlyTokens []string `json:"read_only_tokens"`
 	// Authentication tokens for read-write access.
 	ReadWriteTokens []string `json:"read_write_tokens"`
+	// ReadTimeout is the maximum duration (in seconds) for reading the entire request, including the body. Zero or negative value means no timeout.
+	ReadTimeout time.Duration `json:"read_timeout"`
+	// WriteTimeout is the maximum duration (in seconds) for writing the response. Zero or negative value means no timeout.
+	WriteTimeout time.Duration `json:"write_timeout"`
 }
 
 // NewServer creates a new Server.
@@ -101,8 +105,8 @@ func (s *Server) Start(ctx context.Context, ready chan struct{}) error {
 
 	srv := &http.Server{
 		Addr:         addr,
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
+		WriteTimeout: s.WriteTimeout,
+		ReadTimeout:  s.ReadTimeout,
 		IdleTimeout:  60 * time.Second,
 		Handler:      r,
 	}


### PR DESCRIPTION
fixes #44

* add `-read_timeout` and `-write_timeout` flags
* add marshaler/unmarshaler for `time.Duration` in JSON
* default write timeout is set to zero (no timeout)