### PR TITLE
add cors header on get response

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -313,6 +313,9 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) (int, any) {
 	}
 	log.Printf("GET %s -> %s", r.URL.Path, requestPath)
 	f, err := s.fs.Open(requestPath)
+	if s.EnableCORS {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
 	if err != nil {
 		// ErrNotExist is a common case so don't log it
 		if errors.Is(err, os.ErrNotExist) {

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -21,10 +21,10 @@ func TestGetHandler(t *testing.T) {
 		Url    string
 	}
 	tests := []struct {
-		name string
-		args args
-		want int
-		body string
+		name    string
+		args    args
+		want    int
+		body    string
 		headers map[string]string
 	}{
 		{
@@ -121,10 +121,11 @@ func TestServer_PostHandler(t *testing.T) {
 		Name    string
 	}
 	tests := []struct {
-		name string
-		args args
-		want int
-		body string
+		name    string
+		args    args
+		want    int
+		body    string
+		headers map[string]string
 	}{
 		{
 			name: "Post hello.txt",
@@ -135,6 +136,9 @@ func TestServer_PostHandler(t *testing.T) {
 				Name:    "hello.txt",
 			},
 			want: http.StatusCreated,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":true,"path":"/files/hello.txt"}`,
 		},
 		{
@@ -146,6 +150,9 @@ func TestServer_PostHandler(t *testing.T) {
 				Name:    "empty",
 			},
 			want: http.StatusCreated,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":true,"path":"/files/empty"}`,
 		},
 		{
@@ -256,6 +263,11 @@ func TestServer_PostHandler(t *testing.T) {
 					t.Errorf("failed to verify. request body = %v, local file = %v", tt.args.Content, uploaded)
 				}
 			}
+			for k, v := range tt.headers {
+				if rr.Header().Get(k) != v {
+					t.Errorf("header %s = %s, want %s", k, rr.Header().Get(k), v)
+				}
+			}
 		})
 	}
 }
@@ -269,10 +281,11 @@ func TestServer_PutHandler(t *testing.T) {
 		Name    string
 	}
 	tests := []struct {
-		name string
-		args args
-		want int
-		body string
+		name    string
+		args    args
+		want    int
+		body    string
+		headers map[string]string
 	}{
 		{
 			name: "PUT /files/hello.txt with text",
@@ -283,6 +296,9 @@ func TestServer_PutHandler(t *testing.T) {
 				Name:    "hello.txt",
 			},
 			want: http.StatusCreated,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":true,"path":"/files/hello.txt"}`,
 		},
 		{
@@ -294,6 +310,9 @@ func TestServer_PutHandler(t *testing.T) {
 				Name:    "empty",
 			},
 			want: http.StatusCreated,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":true,"path":"/files/empty"}`,
 		},
 		{
@@ -305,6 +324,9 @@ func TestServer_PutHandler(t *testing.T) {
 				Name:    "world.txt",
 			},
 			want: http.StatusCreated,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":true,"path":"/files/hello/world.txt"}`,
 		},
 		{
@@ -399,6 +421,11 @@ func TestServer_PutHandler(t *testing.T) {
 				}
 				if !reflect.DeepEqual(uploaded, tt.args.Content) {
 					t.Errorf("failed to verify. request body = %v, local file = %v", tt.args.Content, uploaded)
+				}
+			}
+			for k, v := range tt.headers {
+				if rr.Header().Get(k) != v {
+					t.Errorf("header %s = %s, want %s", k, rr.Header().Get(k), v)
 				}
 			}
 		})

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -25,6 +25,7 @@ func TestGetHandler(t *testing.T) {
 		args args
 		want int
 		body string
+		headers map[string]string
 	}{
 		{
 			name: "get existing file",
@@ -33,6 +34,9 @@ func TestGetHandler(t *testing.T) {
 				Url:    "/files/foo/bar.txt",
 			},
 			want: http.StatusOK,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: "hello, world",
 		},
 		{
@@ -42,6 +46,9 @@ func TestGetHandler(t *testing.T) {
 				Url:    "/files/bar/baz",
 			},
 			want: http.StatusNotFound,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":false,"error":"file not found"}`,
 		},
 		{
@@ -60,6 +67,9 @@ func TestGetHandler(t *testing.T) {
 				Url:    "/files/foo",
 			},
 			want: http.StatusNotFound,
+			headers: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
 			body: `{"ok":false,"error":"foo is a directory"}`,
 		},
 	}
@@ -92,6 +102,11 @@ func TestGetHandler(t *testing.T) {
 			}
 			if body := rr.Body.String(); body != tt.body {
 				t.Errorf("body = \"%s\", want = \"%s\"", body, tt.body)
+			}
+			for k, v := range tt.headers {
+				if rr.Header().Get(k) != v {
+					t.Errorf("header %s = %s, want %s", k, rr.Header().Get(k), v)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Allow simple requests (those made without a preflight request) to access the files from a cross-origin when the cors configuration is enabled.
- Improve CORS test coverage for POST and PUT methods.

Rationale: while using this project to serve local files in a development environment, I found the need to have this to simplify the developer experience.
 