### PR TITLE
Apply timeout flags after merge so explicit zero disables the timeout

### DIFF
--- a/app.go
+++ b/app.go
@@ -284,6 +284,21 @@ func (a *app) ParseConfig(args []string) (*simpleuploadserver.ServerConfig, erro
 	}
 	log.Printf("merged flag config: %+v", config)
 
+	// mergo.WithOverride does not override a destination field with a zero-value
+	// source field. An explicit `-read_timeout 0` parses to the zero value, which
+	// is indistinguishable from an unset flag, so it never overrides the non-zero
+	// default ReadTimeout and the documented "zero ... means no timeout" cannot be
+	// selected. Apply the timeout flags directly when the user actually provided
+	// them so that an explicit 0 disables the timeout as documented.
+	a.flagSet.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "read_timeout":
+			config.ReadTimeout = Duration(a.readTimeout)
+		case "write_timeout":
+			config.WriteTimeout = Duration(a.writeTimeout)
+		}
+	})
+
 	v := config.AsConfig()
 	return &v, nil
 }


### PR DESCRIPTION
Fixes #50.

## Problem

In `ParseConfig`, `mergo.Merge(&config, configFromFlags, mergo.WithOverride)` does not override a destination field when the source field is a zero value. An explicit `-read_timeout 0` parses to the zero value — indistinguishable from an unset flag — so it never overrides the non-zero default `ReadTimeout` (15s). The documented behaviour "zero or negative value means no timeout" was therefore only reachable with a negative duration; `0` silently fell back to 15s, cutting long uploads at 15s.

## Fix

After the flag merge, re-apply the read/write timeout flags directly when the user actually provided them, using `flag.Visit`. This mirrors the existing `IsSet()` handling used for the bool flags. An explicit `0` now disables the timeout as documented; an unset flag keeps the default.

## Behaviour

| args | before | after |
| --- | --- | --- |
| (unset) | 15s | 15s |
| `-read_timeout 0` | 15s | 0 (no timeout) |
| `-read_timeout=-1s` | -1s | -1s |
| `-read_timeout 30s` | 30s | 30s |

## Testing

`go build ./...` and `gofmt` are clean, and `go test ./...` passes. Verified the four cases above with a table test against `ParseConfig`.